### PR TITLE
Moving all questions into details/summary elements

### DIFF
--- a/a11y.md
+++ b/a11y.md
@@ -1,11 +1,16 @@
 # Accessibility   
 
-**Do I need to make my app accessible?**  
+<details>
+<summary>Do I need to make my app accessible?</summary>
+
 People will visit your website for a purpose. It may be reading the news, or finding a flight, you name it. Your visitors may be visually impaired, suffer from epilepsy or have trouble understanding complicated sentences. Think about these people, try imagine being them, and answer yourself a simple question: do I want to make their lifes even harder?
 
-<br/><br/>
+</details>
 
-**How do I make my app accessible?**  
+----
+
+<details>
+<summary>How do I make my app accessible?</summary>
 
 This is a big question, as accessibility (often abbreviated _a11y_) encompasses quite a lot of things from supporting screen readers and keyboard navigation, to ensuring the colors used in your designs offer an appropriate amount of contrast.
 
@@ -21,3 +26,5 @@ Finally, here are some helpful resources for ensuring your site is accessible:
 - [Contrast Ratio Calculator](https://contrast-ratio.com) - A tool from Lee Veroux which helps to determine if the colours you're using in your designs offer an appropriate amount of contrast.
 - [tota11y](https://khan.github.io/tota11y) - A tool from Khan Academy which helps you visualize how your site will perform with assostive technology.
 - [eslint-jsx-a11y](https://www.npmjs.com/package/eslint-plugin-jsx-a11y) - An ESLint plugin which helps you spot accessibility issues with JSX code in React projects.
+
+</details>

--- a/css.md
+++ b/css.md
@@ -1,18 +1,28 @@
 # CSS
 
-**What is the difference between absolute and fixed positioning?**  
+<details>
+<summary>What is the difference between absolute and fixed positioning?</summary>
+
 _Absolute positioning allows you to place any page element exactly where you want it._ You use the positioning attributes top, left, bottom. and right to set the location. Ex. `position: absolute; top: 40px; left: 40px;` (These values are relative to the parent element). When you absolute position an element you treat it as an independent element on the page, which means it  will not be affected by other elements and it won't affect other elements.
 
 _A fixed position element is positioned relative to the viewport, or the browser window itself._ This is often used for navigation or sidebars because the viewport does not change at scrolling. So your fixed element will remain at the exact position you set it at. Ex. `position: fixed; top: 80px; left: 10px;`  
 
-<br/><br/>
+</details>
 
-**What is the best/most performant way to include media queries? Is it better to put them all in one CSS file or split them up into different CSS files per component or page?**  
+----
+
+<details>
+<summary>What is the best/most performant way to include media queries? Is it better to put them all in one CSS file or split them up into different CSS files per component or page?</summary>
+
+</details>
+
 _Waiting for response_
 
-<br/><br/>
+----
 
-**What are CSS pre-processors and how do I get started with one?**   
+<details>
+<summary>What are CSS pre-processors and how do I get started with one?</summary>
+
 CSS pre-processors provide additional functionalities to CSS. Each one has its own syntax (which is generally very similar to CSS) and they compile down to CSS through a compiler.
 
 1. Why would I use a pre-processor?
@@ -24,3 +34,5 @@ CSS pre-processors provide additional functionalities to CSS. Each one has its o
 3. How do I get started?
 - To use most of these, you would need a form of compiler or processor to compile the files down to CSS. How they generally work is that you ask them to watch a file(.sass, .less et al.) and they compile these files on the fly. [Koala](http://koala-app.com/) is one such option for SASS and LESS.
 - If you are using [VS Code](https://code.visualstudio.com/), then you can install plugins that will act as a compiler and do it for you. [Live Sass Compiler](https://marketplace.visualstudio.com/items?itemName=ritwickdey.live-sass) is an example of such an extension.
+
+</details>

--- a/css.md
+++ b/css.md
@@ -3,7 +3,7 @@
 <details>
 <summary>What is the difference between absolute and fixed positioning?</summary>
 
-_Absolute positioning allows you to place any page element exactly where you want it._ You use the positioning attributes top, left, bottom. and right to set the location. Ex. `position: absolute; top: 40px; left: 40px;` (These values are relative to the parent element). When you absolute position an element you treat it as an independent element on the page, which means it  will not be affected by other elements and it won't affect other elements.
+_Absolute positioning allows you to place any page element exactly where you want it._ You use the positioning attributes `top`, `left`, `bottom`, and `right` to set the location. Eg. `position: absolute; top: 40px; left: 40px;`. These values are relative to the closest parent element that is **not** set to `position: static` (the default value for the `position` property). When you absolute position an element you treat it as an independent element on the page, which means it  will not be affected by other elements and it won't affect other elements.
 
 _A fixed position element is positioned relative to the viewport, or the browser window itself._ This is often used for navigation or sidebars because the viewport does not change at scrolling. So your fixed element will remain at the exact position you set it at. Ex. `position: fixed; top: 80px; left: 10px;`  
 

--- a/css.md
+++ b/css.md
@@ -14,6 +14,8 @@ _A fixed position element is positioned relative to the viewport, or the browser
 <details>
 <summary>What is the best/most performant way to include media queries? Is it better to put them all in one CSS file or split them up into different CSS files per component or page?</summary>
 
+If you know the answer to this question, please submit a pull request with the answer.
+
 </details>
 
 _Waiting for response_

--- a/general.md
+++ b/general.md
@@ -16,6 +16,7 @@ If you prefer to quickly try a new progrmaming language, you might like this lis
 <details>
 <summary>As a Java backend developer that would like to do more front-end, do you need a strong level in CSS to become a front end developer?</summary>
 
+If you know the answer to this question, please submit a pull request with the answer.
 
 </details>
 
@@ -26,6 +27,8 @@ _Waiting for response_
 <details>
 <summary>What is the best place to buy a domain name?</summary>
 
+If you know the answer to this question, please submit a pull request with the answer.
+
 </details>
 
 _Waiting for response_
@@ -34,6 +37,8 @@ _Waiting for response_
 
 <details>
 <summary>How do I host a website on GitHub?</summary>
+
+If you know the answer to this question, please submit a pull request with the answer.
 
 </details>
 

--- a/general.md
+++ b/general.md
@@ -1,23 +1,40 @@
  # General
- **Which IDE or code editor should I use?**
- 
+
+<details>
+<summary>Which IDE or code editor should I use?</summary>
+
 [VS Code](https://code.visualstudio.com) is a great choice and provides a lot of web friendly features out of the box, along with many 3rd party extensions to customize it just the way you like.
 
 Some other alternatives are [Atom](https://atom.io), [Sublime Text](https://www.sublimetext.com), [WebStorm](https://www.jetbrains.com/webstorm/).
 
 If you prefer to quickly try a new progrmaming language, you might like this list of [Awesome Online IDEs](https://ide.ceriously.com).
 
-<br/><br/>
+</details>
 
-**As a Java backend developer that would like to do more front-end, do you need a strong level in CSS to become a front end developer?**  
- _Waiting for response_
+----
 
-<br/><br/>
+<details>
+<summary>As a Java backend developer that would like to do more front-end, do you need a strong level in CSS to become a front end developer?</summary>
 
-**What is the best place to buy a domain name?**
+
+</details>
+
 _Waiting for response_
 
-<br/><br/>
+----
 
-**How do I host a website on GitHub?**   
+<details>
+<summary>What is the best place to buy a domain name?</summary>
+
+</details>
+
+_Waiting for response_
+
+----
+
+<details>
+<summary>How do I host a website on GitHub?</summary>
+
+</details>
+
 _Waiting for response_

--- a/html.md
+++ b/html.md
@@ -1,5 +1,7 @@
-# HTML   
-**What are `<div>` and `<span>`?  Why would you use them?**
+# HTML
+
+<details>
+<summary>What are `<div>` and `<span>`?  Why would you use them?</summary>
 
 All HTML documents have two types of element - block and inline.  A `<p>`, or paragraph is an example of a block element; `<strong>` is an example of an inline element. These elements are treated differently when a browser dislays your page:
 - a block level element has 100% width by default and any subsequent elements will appear below it.
@@ -10,3 +12,5 @@ Most elements in HTML are designed for a specific purpose - a paragraph, a headi
 `<span>`s can be used to differentiate parts of the text in a paragraph - maybe you have a brand name that you want to style differently everywhere it appears - wrap it in a span and give it a class (`<span class="brand-mark">AwesomeBrandName</span>`) - you can then change the look of that text in your CSS.
 
 `<div>`s can be used to break up your content into distinct areas or types - maybe an interactive image area, or the graph with flyout. With the addition of HTML5 elements such as `<footer>`, `<main>` and `<nav>`, the number of uses of a `<div>` has gone down, but you will definitely still run into situations where nothing else fits and you pull the trusty `<div>` out of your toolbox!
+
+</details>

--- a/js.md
+++ b/js.md
@@ -1,6 +1,8 @@
 # JavaScript   
 
-**What is a Promise and how do you use it?**  
+<details>
+<summary>What is a Promise and how do you use it?</summary>
+
 Normally, JavaScript executes statements one at a time. It will not continue with the next statement until the last one has been executed. A Promise is a piece of code that _promises_ to return some data later. This allows you to execute code in a returned Promise _asynchronously_ from the rest of your code. More importantly, once your Promise resolves (that is: It returns the data it promised to return earlier), you can use this result in chained code.
 
 There are two ways to use Promises. The first one is by chaining a function that will be executed when the Promise resolves with the data it promised. The example below showcases a use case where we do a request to an API, then use the result of that API call. `getPolarBears` is the function that _promises_ to return a list of polar bears. The Promise resolves when the `resolve` function is called. When the Promise resolves, the function you passed to the chained `.then(..)` will be called with the result.
@@ -39,10 +41,15 @@ async function doStuff() {
   }
 }
 ```
+</details>
 
-<br/><br/>
+----
 
-**Is it fine to learn JavaScript as your first language for web development or is it better to start with HTML and CSS**   
+<details>
+<summary>Is it fine to learn JavaScript as your first language for web development or is it better to start with HTML and CSS</summary>
+
 Learn HTML and CSS first. Many take HTML and CSS understanding for granted. But without a clear understanding of the DOM and CSS you will struggle as a Web Developer. Not being able to cleanly and effectively assemble your layout with a stable set of styles can easily turn a 1-day task into a 2-week nightmare.
 
-The big misnomer is that many individuals learn things just enough to be able to Google if they get stuck. CSS isn't one of those things. You can't Google your way out of a CSS bug. The only way is to understand how the cascade works. Once you fully understand CSS then move on to JavaScript. 
+The big misnomer is that many individuals learn things just enough to be able to Google if they get stuck. CSS isn't one of those things. You can't Google your way out of a CSS bug. The only way is to understand how the cascade works. Once you fully understand CSS then move on to JavaScript.
+
+</details>

--- a/node.md
+++ b/node.md
@@ -3,6 +3,8 @@
 <details>
 <summary>Where do I find other people's Node.js code for small projects? GitHub doesn't seem to display it?</summary>
 
+If you know the answer to this question, please submit a pull request with the answer.
+
 </details>
 
 _Waiting for response_

--- a/node.md
+++ b/node.md
@@ -1,4 +1,8 @@
 # Node 
- 
-**Where do I find other people's Node.js code for small projects? GitHub doesn't seem to display it?**  
+
+<details>
+<summary>Where do I find other people's Node.js code for small projects? GitHub doesn't seem to display it?</summary>
+
+</details>
+
 _Waiting for response_

--- a/performance.md
+++ b/performance.md
@@ -1,12 +1,21 @@
 # Performance   
 
-**What is the best way to reduce my image file size?** 
+<details>
+<summary>What is the best way to reduce my image file size?</summary>
 
 >At minimum: use [ImageOptim](https://imageoptim.com/). It can significantly reduce the size of images while preserving visual quality. Windows and Linux [alternatives](https://imageoptim.com/versions.html) are also available.
 
 >More specifically: run your JPEGs through [MozJPEG](https://github.com/mozilla/mozjpeg0) (q=80 or lower is fine for web content) and consider [Progressive JPEG](http://cloudinary.com/blog/progressive_jpegs_and_green_martians) support, PNGs through [pngquant](https://pngquant.org/) and SVGs through [SVGO](https://github.com/svg/svgo). Explicitly strip out metadata (--strip for pngquant) to avoid bloat. Instead of crazy huge animated GIFs, deliver [H.264](https://en.wikipedia.org/wiki/H.264/MPEG-4_AVC) videos (or [WebM](https://www.webmproject.org/) for Chrome, Firefox and Opera)! If you can’t at least use [Giflossy](https://github.com/pornel/giflossy). If you can spare the extra CPU cycles, need higher-than-web-average quality and are okay with slow encode times: try [Guetzli](https://research.googleblog.com/2017/03/announcing-guetzli-new-open-source-jpeg.html).
 
-From the excellent [images.guide](https://images.guide/). <br/><br/>
+From the excellent [images.guide](https://images.guide/).
 
-**What is the best format for performant images? PNG? JPG? SVG?**  
-> It's between SVG and JPG. It really depends on how much detail and color variation the image has. If it's a simple vector graphic (_Something like a logo or icon_) you should safely be able to go with SVG. This can be under 1k - 5k in size. If the image is more like a photo with a considerable amount of detail and colors I would go with JPG. You should only feel compelled to reach for PNG if the file has transparency.
+</details>
+
+----
+
+<details>
+<summary>What is the best format for performant images? PNG? JPG? SVG?</summary>
+
+It's between SVG and JPG. It really depends on how much detail and color variation the image has. If it's a simple vector graphic (_Something like a logo or icon_) you should safely be able to go with SVG. This can be under 1k - 5k in size. If the image is more like a photo with a considerable amount of detail and colors I would go with JPG. You should only feel compelled to reach for PNG if the file has transparency.
+
+</details>

--- a/react.md
+++ b/react.md
@@ -1,7 +1,10 @@
 # React
 
-**What are the pre requesites(excluding the general HTML, CSS, and JS) before starting off with React?**
+<details>
+<summary>What are the pre requesites(excluding the general HTML, CSS, and JS) before starting off with React?</summary>
 
-Apart from HTML, CSS and a good level of comfort with Javascript, learning react requires one to be be familiar with Object Oriented Concepts since React uses alot of inheritance from classes and methods that are used to create both functional and presentational components. Knowledge of Single Page Applications is also important as it will give you an idea of how routing happens with the understanding that the routes are dynamic and not physical pages on the server. To set up you can either use a [script tag](https://reactjs.org/docs/add-react-to-a-website.html) that pulls in React in your project or to set up using [create-react-app](https://github.com/facebook/create-react-app) from Facebook. You can then write your own React code in a simple JS file for functional components and JSX file for presentational components. 
+Apart from HTML, CSS and a good level of comfort with Javascript, learning react requires one to be be familiar with Object Oriented Concepts since React uses a lot of inheritance from classes and methods that are used to create both functional and presentational components. Knowledge of Single Page Applications is also important as it will give you an idea of how routing happens with the understanding that the routes are dynamic and not physical pages on the server. To set up you can either use a [script tag](https://reactjs.org/docs/add-react-to-a-website.html) that pulls in React in your project or to set up using [create-react-app](https://github.com/facebook/create-react-app) from Facebook. You can then write your own React code in a simple JS file for functional components and JSX file for presentational components.
 
 You can start with the official docs' [getting started](https://reactjs.org/docs/getting-started.html) page which are very beginner friendly.
+
+</details>

--- a/testing.md
+++ b/testing.md
@@ -3,6 +3,8 @@
 <details>
 <summary>What is the best way to unit test a function which uses external APIs, particularly DOM APIs? Mock / Stub window and document objects, or run your tests in those environments where they're available?</summary>
 
+If you know the answer to this question, please submit a pull request with the answer.
+
 </details>
 
 _Waiting for response_

--- a/testing.md
+++ b/testing.md
@@ -1,4 +1,8 @@
 # Testing
 
-**What is the best way to unit test a function which uses external APIs, particularly DOM APIs? Mock / Stub window and document objects, or run your tests in those environments where they're available?**  
+<details>
+<summary>What is the best way to unit test a function which uses external APIs, particularly DOM APIs? Mock / Stub window and document objects, or run your tests in those environments where they're available?</summary>
+
+</details>
+
 _Waiting for response_


### PR DESCRIPTION
**Original markdown**

```html
**Question**

Answer
```

**new markdown**

```html
<details>
<summary>Question</summary>

Answer

</details>
```

----

This change improves both the accessibility and the usability of the repository.

From a semantic standpoint,  `<details>` and `<summary>` elements provide much better semantic meaning to screen reader users than `<p><strong>Question</strong><p>` and `<p>Answer</p>`.

From a usability point of view, it allows users to quickly scan through all the questions so that they can find what they are looking for more easily.

I have intentionally left the "_Waiting for response_" messages outside of the  `<details>` elements so that users looking for answers will know not to bother opening those segments and users that are looking for questions to answer  will quickly be able to find the unanswered ones. Inside the `<details>` section of these unhanswered questions, I have written a call to action asking people who know the answer to submit a pull request.

There is also the bonus effect that many Junior Front End Developers do not know about the `<details>` and `<summary>` elements. Discovering them through this repository could be exciting for them.